### PR TITLE
Add Swift Package Manager Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# macOS
+.DS_Store
+
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+.swiftpm

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version:5.7
+import PackageDescription
+
+
+let package = Package(
+    name: "EstimoteBluetoothScanning",
+    platforms: [
+        .iOS(.v10)
+    ],
+    products: [
+        .library(
+            name: "EstimoteBluetoothScanning",
+            targets: [
+                "EstimoteBluetoothScanning"
+            ]
+        )
+    ],
+    targets: [
+        .binaryTarget(
+            name: "EstimoteBluetoothScanning",
+            path: "./EstimoteBluetoothScanning/EstimoteBluetoothScanning.xcframework"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # iOS-Bluetooth-Scanning
 
 Library for scanning Bluetooth packets broadcasted by Estimote devices.
+
+## Installation
+
+### Swift Package Manager 
+
+Follow the article about [Adding Package Dependencies to Your App](https://developer.apple.com/documentation/xcode/adding-package-dependencies-to-your-app) using the following repository URL: `https://github.com/Estimote/iOS-Bluetooth-Scanning`.


### PR DESCRIPTION
You can import it into your project or add it to your Swift Package by following the article about [Adding Package Dependencies to Your App](https://developer.apple.com/documentation/xcode/adding-package-dependencies-to-your-app) using the following repository URL: `https://github.com/Estimote/iOS-Bluetooth-Scanning`. 

You will need to tag a new release to enable developers to start importing the SDK using the Swift Package Manager.